### PR TITLE
[ENH] Added sizing property

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The `fontawesome-icon` component has the following attributes:
 |-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | prefix      | The icon's prefix. Can be `fas`,`far`, or `fab`.                                                                                                                                           |
 | name        | The icon's name (without `fa-` prefix).                                                                                                                                                    |
+| sizing        | The icon's sizing as defined in the [FontAwesome docs](https://fontawesome.com/how-to-use/on-the-web/styling/sizing-icons).    |
 | fixed-width | If this boolean attribute is specified, the icon is set to the same fixed width independent of the actual icon (see [FontAwesome docs](https://fontawesome.com/how-to-use/svg-with-js)).   |
 
 ## Limitations

--- a/fontawesome-icon.js
+++ b/fontawesome-icon.js
@@ -24,6 +24,8 @@ class FontawesomeIcon extends PolymerElement {
       prefix: String,
       /** FontAwesome icon name */
       name: String,
+      /** FontAwesome icon sizing */
+      sizing: String,
       /** FontAwesome fixed width parameter (fa-fw) */
       fixedWidth: Boolean,
       /** FontAwesom spin option (fa-spin) */
@@ -33,7 +35,7 @@ class FontawesomeIcon extends PolymerElement {
 
   static get observers() {
     return [
-      '_iconChanged(prefix, name, fixedWidth, spin)'
+      '_iconChanged(prefix, name, sizing, fixedWidth, spin)'
     ]
   }
 
@@ -50,7 +52,7 @@ class FontawesomeIcon extends PolymerElement {
     this.root.appendChild(faStyles);
   }
 
-  _iconChanged(prefix, iconName, fixedWidth, spin) {
+  _iconChanged(prefix, iconName, sizing, fixedWidth, spin) {
     let iconDef = fontawesome.findIconDefinition({prefix, iconName});
     if(!iconDef) {
       iconDef = fontawesome.findIconDefinition({prefix: 'far', iconName: 'question-circle'})
@@ -62,6 +64,9 @@ class FontawesomeIcon extends PolymerElement {
     }
     if(spin) {
       options.classes.push('fa-spin');
+    }
+    if(sizing) {
+      options.classes.push(sizing);
     }
     this.$.container.innerHTML = fontawesome.icon(iconDef, options).html;
   }


### PR DESCRIPTION
This allows users to include a standard fontawesome sizing property as defined at https://fontawesome.com/how-to-use/on-the-web/styling/sizing-icons

Example:
```
<fontawesome-icon prefix="fab" name="linkedin"  sizing="fa-2x" fixed-width></fontawesome-icon>
```